### PR TITLE
temporarily fixed 'Binding element x implicitly has an 'any' type in TypeScript'

### DIFF
--- a/components/ui/button/index.tsx
+++ b/components/ui/button/index.tsx
@@ -1,11 +1,17 @@
 import { FaBookOpen, FaUserCircle, FaBars } from "react-icons/fa";
 
+interface Props {
+  children?: any,
+  className?: any,
+  title?: string,
+  onClick?: any
+}
 export default function Button({
   children,
   className,
   title,
   onClick = () => {},
-}) {
+}: Props){
   const defaultClassNames = "shadow-md focus:cursor-pointer";
   return (
     <button

--- a/components/ui/card/index.tsx
+++ b/components/ui/card/index.tsx
@@ -1,4 +1,10 @@
-function Card({ className, title, onClick = () => {} }) {
+interface Props {
+  children?: any,
+  className?: any,
+  title?: string,
+  onClick?: any
+}
+function Card({ className, title, onClick = () => {} }: Props) {
   const defaultClassNames = "shadow-md focus:cursor-pointer";
   return (
     <div


### PR DESCRIPTION
There's a Typescript error when you don't specify the types for your props, so I tried to "define" the possible type of props that were to be passed in the functions. Since I am not very familiar with props, I bypassed most of the types with 'any' in order to progress. 